### PR TITLE
.editorconfigの導入

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_stype = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_stype = tab
+indent_style = tab
 indent_size = 4
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
## 概要
.editorconfigの導入

## 参考
```
indent_stype = tab ## tab or space
indent_size = 4 ## インデント幅
end_of_line = lf ## lf or cr or crlf
charset = utf-8 ## 文字コード
trim_trailing_whitespace = true　## 改行文字の前にある空白文字を除外。CSV形式のファイルは falseに設定することが多い
insert_final_newline = true　## trueにすると、保存時にファイルが改行で終わるようにできる
```